### PR TITLE
feat: 5 add headers field to application.yml in IncomingRequests, rename params to query, evaluate body, query and headers before each request, switch headers map value type from string to Object and add test for new feature

### DIFF
--- a/samples/steps/http-get.md
+++ b/samples/steps/http-get.md
@@ -20,9 +20,9 @@ get_step:
 
 * `args`
     * `query`
-        * *..desired query values*
+        * *..desired query values* - Scripts can be used for query values
     * `headers`
-        * *..desired header values*
+        * *..desired header values* - Scripts can be used for headers values
     * `result` - name of the variable to store the response of the query in, for use in other steps
 
 #### How responses are stored with the result field

--- a/samples/steps/http-post.md
+++ b/samples/steps/http-post.md
@@ -24,9 +24,9 @@ post_step:
 
 * `args`
     * `query`
-        * *..desired query values*
+        * *..desired query values* - Scripts can be used for query values
     * `headers`
-        * *..desired header values*
+        * *..desired header values* - Scripts can be used for headers values
     * `result` - name of the variable to store the response of the query in, for use in other steps
 
 ***Note: POST step responses are stored the same way as [GET step responses](./http-get.md#How-responses-are-stored-with-the-result-field)***

--- a/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
+++ b/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,6 +33,7 @@ public class ApplicationProperties {
     public static class IncomingRequests {
         private List<String> allowedMethodTypes;
         private ExternalForwarding externalForwarding = new ExternalForwarding();
+        private Map<String, Object> headers = new HashMap<>();
 
         @Getter
         @Setter
@@ -60,6 +62,6 @@ public class ApplicationProperties {
     @Getter
     @Setter
     public static class HttpPost {
-        private Map<String, String> headers;
+        private Map<String, Object> headers;
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/controller/ConfigurationController.java
+++ b/src/main/java/ee/buerokratt/ruuter/controller/ConfigurationController.java
@@ -27,14 +27,15 @@ public class ConfigurationController {
     @RequestMapping(value = "/{configuration}")
     public ResponseEntity<RuuterResponse> queryConfiguration(@PathVariable String configuration,
                                                              @RequestBody(required = false) Map<String, Object> requestBody,
-                                                             @RequestParam(required = false) Map<String, Object> requestParams,
+                                                             @RequestParam(required = false) Map<String, Object> requestQuery,
+                                                             @RequestHeader(required = false) Map<String, String> requestHeaders,
                                                              HttpServletRequest request) {
         if (!properties.getIncomingRequests().getAllowedMethodTypes().contains(request.getMethod())) {
             String errorMsg = "Request received with invalid method type %s for configuration: %s".formatted(request.getMethod(), configuration);
             LoggingUtils.logError(log, errorMsg, request.getRemoteAddr(), INCOMING_REQUEST);
             return status(HttpStatus.METHOD_NOT_ALLOWED).body(new RuuterResponse());
         }
-        ConfigurationInstance ci = configurationService.execute(configuration, request.getMethod(),  requestBody, requestParams, request.getRemoteAddr());
+        ConfigurationInstance ci = configurationService.execute(configuration, request.getMethod(),  requestBody, requestQuery, requestHeaders, request.getRemoteAddr());
         return status(HttpStatus.OK)
             .headers(httpHeaders -> ci.getReturnHeaders().forEach(httpHeaders::add))
             .body(new RuuterResponse(ci.getReturnValue()));

--- a/src/main/java/ee/buerokratt/ruuter/domain/ConfigurationInstance.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/ConfigurationInstance.java
@@ -22,7 +22,8 @@ import java.util.Map;
 public class ConfigurationInstance {
     private final Map<String, ConfigurationStep> steps;
     private final Map<String, Object> requestBody;
-    private final Map<String, Object> requestParams;
+    private final Map<String, Object> requestQuery;
+    private final Map<String, String> requestHeaders;
     private final String requestOrigin;
     private final ConfigurationService configurationService;
     private final ApplicationProperties properties;
@@ -36,6 +37,7 @@ public class ConfigurationInstance {
     private Map<String, String> returnHeaders = new HashMap<>();
 
     public void execute(String configurationName) {
+        addGlobalIncomingHeadersToRequestHeaders();
         List<String> stepNames = steps.keySet().stream().toList();
         try {
             executeStep(stepNames.get(0), stepNames);
@@ -61,5 +63,11 @@ public class ConfigurationInstance {
         } else if (!previousStep.getNextStepName().equals("end")) {
             executeStep(previousStep.getNextStepName(), stepNames);
         }
+    }
+
+    private void addGlobalIncomingHeadersToRequestHeaders() {
+        Map<String, Object> evaluatedHeaders = scriptingHelper.evaluateScripts(properties.getIncomingRequests().getHeaders(), context, requestBody, requestQuery, requestHeaders);
+        Map<String, String> evaluatedGlobalHeaders = mappingHelper.convertMapObjectValuesToString(evaluatedHeaders);
+        requestHeaders.putAll(evaluatedGlobalHeaders);
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/domain/ConfigurationInstance.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/ConfigurationInstance.java
@@ -67,7 +67,6 @@ public class ConfigurationInstance {
 
     private void addGlobalIncomingHeadersToRequestHeaders() {
         Map<String, Object> evaluatedHeaders = scriptingHelper.evaluateScripts(properties.getIncomingRequests().getHeaders(), context, requestBody, requestQuery, requestHeaders);
-        Map<String, String> evaluatedGlobalHeaders = mappingHelper.convertMapObjectValuesToString(evaluatedHeaders);
-        requestHeaders.putAll(evaluatedGlobalHeaders);
+        requestHeaders.putAll(mappingHelper.convertMapObjectValuesToString(evaluatedHeaders));
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/AssignStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/AssignStep.java
@@ -17,7 +17,7 @@ public class AssignStep<T> extends ConfigurationStep {
 
     @Override
     protected void executeStepAction(ConfigurationInstance ci) {
-        assign.forEach((k, v) -> ci.getContext().put(k, ci.getScriptingHelper().evaluateScripts(v, ci.getContext(), ci.getRequestBody(), ci.getRequestParams())));
+        assign.forEach((k, v) -> ci.getContext().put(k, ci.getScriptingHelper().evaluateScripts(v, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders())));
     }
 
     @Override

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/ConfigurationStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/ConfigurationStep.java
@@ -38,6 +38,7 @@ public abstract class ConfigurationStep {
         }  catch (Exception e) {
             handleFailedResult(ci);
             if (ci.getProperties().getStopInCaseOfException() != null && ci.getProperties().getStopInCaseOfException()) {
+                Thread.currentThread().interrupt();
                 throw new StepExecutionException(name, e);
             }
         } finally {

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/ReturnStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/ReturnStep.java
@@ -26,7 +26,7 @@ public class ReturnStep extends ConfigurationStep {
     @Override
     protected void executeStepAction(ConfigurationInstance ci) {
         ci.setReturnHeaders(formatHeaders(ci));
-        ci.setReturnValue(ci.getScriptingHelper().evaluateScripts(returnValue, ci.getContext(), ci.getRequestBody(), ci.getRequestParams()));
+        ci.setReturnValue(ci.getScriptingHelper().evaluateScripts(returnValue, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders()));
     }
 
     @Override
@@ -35,7 +35,7 @@ public class ReturnStep extends ConfigurationStep {
     }
 
     private Map<String, String> formatHeaders(ConfigurationInstance ci) {
-        Map<String, Object> evaluatedMap = ci.getScriptingHelper().evaluateScripts(headers, ci.getContext(), ci.getRequestBody(), ci.getRequestParams());
+        Map<String, Object> evaluatedMap = ci.getScriptingHelper().evaluateScripts(headers, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
         return evaluatedMap.entrySet().stream().collect(toMap(Entry::getKey, this::entryValueToHeaderString));
     }
 

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/conditional/SwitchStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/conditional/SwitchStep.java
@@ -24,7 +24,7 @@ public class SwitchStep extends ConfigurationStep {
     protected void executeStepAction(ConfigurationInstance ci) {
         ScriptingHelper scriptingHelper = ci.getScriptingHelper();
         Optional<Condition> correctStatement = conditions.stream()
-            .filter(condition -> Boolean.TRUE.equals(scriptingHelper.evaluateScripts(condition.getConditionStatement(), ci.getContext(), ci.getRequestBody(), ci.getRequestParams())))
+            .filter(condition -> Boolean.TRUE.equals(scriptingHelper.evaluateScripts(condition.getConditionStatement(), ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders())))
             .findFirst();
         correctStatement.ifPresent(condition -> this.setNextStepName(condition.getNextStepName()));
     }

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/DefaultHttpService.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/DefaultHttpService.java
@@ -22,7 +22,10 @@ public class DefaultHttpService {
         body.put("statusCode", response.getStatusCodeValue());
         body.put("responseBody", ci.getMappingHelper().convertObjectToString(response.getBody()));
         body.put("failedRequestId", MDC.get("spanId"));
-        Map<String, Map<String, Object>> evaluatedParameters = ci.getScriptingHelper().evaluateRequestParameters(ci, body, query, headers);
-        ci.getConfigurationService().execute(service, "POST", evaluatedParameters.get("body"), evaluatedParameters.get("query"), ci.getMappingHelper().convertMapObjectValuesToString(evaluatedParameters.get("headers")), ci.getRequestOrigin());
+        Map<String, Object> evaluatedBody = ci.getScriptingHelper().evaluateScripts(body, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, Object> evaluatedQuery = ci.getScriptingHelper().evaluateScripts(query, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, Object> evaluatedHeaders = ci.getScriptingHelper().evaluateScripts(headers, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, String> mappedHeaders = ci.getMappingHelper().convertMapObjectValuesToString(evaluatedHeaders);
+        ci.getConfigurationService().execute(service, "POST", evaluatedBody, evaluatedQuery, mappedHeaders, ci.getRequestOrigin());
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/DefaultHttpService.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/DefaultHttpService.java
@@ -7,19 +7,22 @@ import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 
 import java.util.HashMap;
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
 public class DefaultHttpService {
     private String service;
-    private HashMap<String, Object> body = new HashMap<>();
-    private HashMap<String, Object> query;
+    private Map<String, Object> body = new HashMap<>();
+    private Map<String, Object> query = new HashMap<>();
+    private Map<String, Object> headers = new HashMap<>();
 
     public void executeHttpDefaultService(ConfigurationInstance ci, String resultName) {
         ResponseEntity<Object> response = ((HttpStepResult) ci.getContext().get(resultName)).getResponse();
         body.put("statusCode", response.getStatusCodeValue());
         body.put("responseBody", ci.getMappingHelper().convertObjectToString(response.getBody()));
         body.put("failedRequestId", MDC.get("spanId"));
-        ci.getConfigurationService().execute(service, "POST", body, query, ci.getRequestOrigin());
+        Map<String, Map<String, Object>> evaluatedParameters = ci.getScriptingHelper().evaluateRequestParameters(ci, body, query, headers);
+        ci.getConfigurationService().execute(service, "POST", evaluatedParameters.get("body"), evaluatedParameters.get("query"), ci.getMappingHelper().convertMapObjectValuesToString(evaluatedParameters.get("headers")), ci.getRequestOrigin());
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStep.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Map;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -15,7 +17,8 @@ public class HttpGetStep extends HttpStep {
 
     @Override
     public ResponseEntity<Object> getRequestResponse(ConfigurationInstance ci) {
-        return ci.getHttpHelper().doGet(args.getUrl(), args.getQuery(), args.getHeaders());
+        Map<String, Map<String, Object>> evaluatedParameters = ci.getScriptingHelper().evaluateRequestParameters(ci, args.getBody(), args.getQuery(), args.getHeaders());
+        return ci.getHttpHelper().doGet(args.getUrl(), evaluatedParameters.get("query"), ci.getMappingHelper().convertMapObjectValuesToString(evaluatedParameters.get("headers")));
     }
 
     @Override

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStep.java
@@ -17,8 +17,10 @@ public class HttpGetStep extends HttpStep {
 
     @Override
     public ResponseEntity<Object> getRequestResponse(ConfigurationInstance ci) {
-        Map<String, Map<String, Object>> evaluatedParameters = ci.getScriptingHelper().evaluateRequestParameters(ci, args.getBody(), args.getQuery(), args.getHeaders());
-        return ci.getHttpHelper().doGet(args.getUrl(), evaluatedParameters.get("query"), ci.getMappingHelper().convertMapObjectValuesToString(evaluatedParameters.get("headers")));
+        Map<String, Object> evaluatedQuery = ci.getScriptingHelper().evaluateScripts(args.getQuery(), ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, Object> evaluatedHeaders = ci.getScriptingHelper().evaluateScripts(args.getHeaders(), ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, String> mappedHeaders = ci.getMappingHelper().convertMapObjectValuesToString(evaluatedHeaders);
+        return ci.getHttpHelper().doGet(args.getUrl(), evaluatedQuery, mappedHeaders);
     }
 
     @Override

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpPostStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpPostStep.java
@@ -18,8 +18,11 @@ public class HttpPostStep extends HttpStep {
     @Override
     protected ResponseEntity<Object> getRequestResponse(ConfigurationInstance ci) {
         args.addHeaders(ci.getProperties().getHttpPost().getHeaders());
-        Map<String, Map<String, Object>> evaluatedParameters = ci.getScriptingHelper().evaluateRequestParameters(ci, args.getBody(), args.getQuery(), args.getHeaders());
-        return ci.getHttpHelper().doPost(args.getUrl(), evaluatedParameters.get("body"), evaluatedParameters.get("query"), ci.getMappingHelper().convertMapObjectValuesToString(evaluatedParameters.get("headers")));
+        Map<String, Object> evaluatedBody = ci.getScriptingHelper().evaluateScripts(args.getBody(), ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, Object> evaluatedQuery = ci.getScriptingHelper().evaluateScripts(args.getQuery(), ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, Object> evaluatedHeaders = ci.getScriptingHelper().evaluateScripts(args.getHeaders(), ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
+        Map<String, String> mappedHeaders = ci.getMappingHelper().convertMapObjectValuesToString(evaluatedHeaders);
+        return ci.getHttpHelper().doPost(args.getUrl(), evaluatedBody, evaluatedQuery, mappedHeaders);
     }
 
     @Override

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpPostStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpPostStep.java
@@ -18,8 +18,8 @@ public class HttpPostStep extends HttpStep {
     @Override
     protected ResponseEntity<Object> getRequestResponse(ConfigurationInstance ci) {
         args.addHeaders(ci.getProperties().getHttpPost().getHeaders());
-        Map<String, Object> evaluatedBody = ci.getScriptingHelper().evaluateScripts(args.getBody(), ci.getContext(), ci.getRequestBody(), ci.getRequestParams());
-        return ci.getHttpHelper().doPost(args.getUrl(), evaluatedBody, args.getQuery(), args.getHeaders());
+        Map<String, Map<String, Object>> evaluatedParameters = ci.getScriptingHelper().evaluateRequestParameters(ci, args.getBody(), args.getQuery(), args.getHeaders());
+        return ci.getHttpHelper().doPost(args.getUrl(), evaluatedParameters.get("body"), evaluatedParameters.get("query"), ci.getMappingHelper().convertMapObjectValuesToString(evaluatedParameters.get("headers")));
     }
 
     @Override

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpQueryArgs.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpQueryArgs.java
@@ -10,9 +10,9 @@ import java.util.Map;
 @NoArgsConstructor
 public class HttpQueryArgs {
     private String url;
-    private Map<String, Object> query;
+    private Map<String, Object> query = new HashMap<>();
     private Map<String, Object> headers = new HashMap<>();
-    private Map<String, Object> body;
+    private Map<String, Object> body = new HashMap<>();
 
     public void addHeaders(Map<String, Object> newHeaders) {
         newHeaders.forEach(headers::putIfAbsent);

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpQueryArgs.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpQueryArgs.java
@@ -3,6 +3,7 @@ package ee.buerokratt.ruuter.domain.steps.http;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Data
@@ -10,14 +11,10 @@ import java.util.Map;
 public class HttpQueryArgs {
     private String url;
     private Map<String, Object> query;
-    private Map<String, String> headers;
+    private Map<String, Object> headers = new HashMap<>();
     private Map<String, Object> body;
 
-    public void addHeaders(Map<String, String> newHeaders) {
-        if (headers == null) {
-            setHeaders(newHeaders);
-        } else {
-            newHeaders.forEach(headers::putIfAbsent);
-        }
+    public void addHeaders(Map<String, Object> newHeaders) {
+        newHeaders.forEach(headers::putIfAbsent);
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpStep.java
@@ -48,7 +48,8 @@ public abstract class HttpStep extends ConfigurationStep {
     @Override
     public void handleFailedResult(ConfigurationInstance ci) {
         super.handleFailedResult(ci);
-        if (!isAllowedHttpStatusCode(ci, ((HttpStepResult) ci.getContext().get(resultName)).getResponse().getStatusCodeValue())) {
+        HttpStepResult stepResult = (HttpStepResult) ci.getContext().get(resultName);
+        if (stepResult != null && !isAllowedHttpStatusCode(ci, stepResult.getResponse().getStatusCodeValue())) {
             DefaultHttpService globalHttpExceptionService = ci.getProperties().getDefaultServiceInCaseOfException();
             if (localHttpExceptionServiceExists()) {
                 localHttpExceptionService.executeHttpDefaultService(ci, resultName);

--- a/src/main/java/ee/buerokratt/ruuter/helper/ExternalForwardingHelper.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/ExternalForwardingHelper.java
@@ -26,16 +26,17 @@ public class ExternalForwardingHelper {
             properties.getIncomingRequests().getExternalForwarding().getProceedPredicate().getHttpStatusCode() != null;
     }
 
-    public ResponseEntity<Object> forwardRequest(Map<String, Object> requestBody, Map<String, Object> requestParams) {
+    public ResponseEntity<Object> forwardRequest(Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders) {
         String forwardingUrl = properties.getIncomingRequests().getExternalForwarding().getEndpoint();
-        Map<String, Object> params = shouldAddParams() ? requestParams : new HashMap<>();
+        Map<String, Object> query = shouldAddParams() ? requestQuery : new HashMap<>();
         Map<String, Object> body = shouldAddBody(requestBody) ? requestBody : new HashMap<>();
+        Map<String, String> headers = shouldAddHeaders(requestHeaders) ? requestHeaders : new HashMap<>();
 
         if (properties.getIncomingRequests().getExternalForwarding().getMethod().equals(HttpMethod.POST.name())) {
-            return httpHelper.doPost(forwardingUrl, body, params, new HashMap<>());
+            return httpHelper.doPost(forwardingUrl, body, query, headers);
         }
         if (properties.getIncomingRequests().getExternalForwarding().getMethod().equals(HttpMethod.GET.name())) {
-            return httpHelper.doGet(forwardingUrl, params, new HashMap<>());
+            return httpHelper.doGet(forwardingUrl, query, headers);
         }
         throw new IllegalArgumentException();
     }
@@ -54,5 +55,9 @@ public class ExternalForwardingHelper {
 
     private boolean shouldAddBody(Map<String, Object> requestBody) {
         return requestBody != null && Boolean.TRUE.equals(properties.getIncomingRequests().getExternalForwarding().getParamsToPass().getPost());
+    }
+
+    private boolean shouldAddHeaders(Map<String, String> requestHeaders) {
+        return requestHeaders != null && Boolean.TRUE.equals(properties.getIncomingRequests().getExternalForwarding().getParamsToPass().getHeaders());
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/helper/HttpHelper.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/HttpHelper.java
@@ -21,12 +21,12 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class HttpHelper {
 
-    public ResponseEntity<Object> doPost(String url, Map<String, Object> body, Map<String, Object> params, Map<String, String> headers) {
+    public ResponseEntity<Object> doPost(String url, Map<String, Object> body, Map<String, Object> query, Map<String, String> headers) {
         WebClient client = WebClient.builder()
             .clientConnector(new ReactorClientHttpConnector(getHttpClient()))
             .baseUrl(url)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .defaultUriVariables(params)
+            .defaultUriVariables(query)
             .build();
 
         try {
@@ -41,12 +41,12 @@ public class HttpHelper {
         }
     }
 
-    public ResponseEntity<Object> doGet(String url, Map<String, Object> params, Map<String, String> headers) {
+    public ResponseEntity<Object> doGet(String url, Map<String, Object> query, Map<String, String> headers) {
         WebClient client = WebClient.builder()
             .clientConnector(new ReactorClientHttpConnector(getHttpClient()))
             .baseUrl(url)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .defaultUriVariables(params)
+            .defaultUriVariables(query)
             .build();
 
         try {

--- a/src/main/java/ee/buerokratt/ruuter/helper/MappingHelper.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/MappingHelper.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,11 @@ public class MappingHelper {
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    public Map<String, String> convertMapObjectValuesToString(Map<String, Object> map) {
+        return map.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
     }
 
     public JsonNode convertMapToNode(Map<String, Object> response) {

--- a/src/main/java/ee/buerokratt/ruuter/helper/ScriptingHelper.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/ScriptingHelper.java
@@ -1,6 +1,5 @@
 package ee.buerokratt.ruuter.helper;
 
-import ee.buerokratt.ruuter.domain.ConfigurationInstance;
 import ee.buerokratt.ruuter.helper.exception.ScriptEvaluationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,17 +23,6 @@ public class ScriptingHelper {
 
     public boolean containsScript(String s) {
         return Pattern.compile(SCRIPT_REGEX, Pattern.MULTILINE).matcher(s).find();
-    }
-
-    public Map<String, Map<String, Object>> evaluateRequestParameters(ConfigurationInstance ci, Map<String, Object> body, Map<String, Object> query, Map<String, Object> headers) {
-        Map<String, Map<String, Object>> evaluatedParameters = new HashMap<>();
-        Map<String, Object> evaluatedBody = ci.getScriptingHelper().evaluateScripts(body, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
-        Map<String, Object> evaluatedQuery = ci.getScriptingHelper().evaluateScripts(query, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
-        Map<String, Object> evaluatedHeaders = ci.getScriptingHelper().evaluateScripts(headers, ci.getContext(), ci.getRequestBody(), ci.getRequestQuery(), ci.getRequestHeaders());
-        evaluatedParameters.put("body", evaluatedBody != null ? evaluatedBody : new HashMap<>());
-        evaluatedParameters.put("query", evaluatedQuery != null ? evaluatedQuery : new HashMap<>());
-        evaluatedParameters.put("headers", evaluatedHeaders != null ? evaluatedHeaders : new HashMap<>());
-        return evaluatedParameters;
     }
 
     public Map<String, Object> evaluateScripts(Map<String, Object> map, Map<String, Object> context, Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders) {

--- a/src/main/java/ee/buerokratt/ruuter/service/ConfigurationService.java
+++ b/src/main/java/ee/buerokratt/ruuter/service/ConfigurationService.java
@@ -59,12 +59,12 @@ public class ConfigurationService {
         }));
     }
 
-    public ConfigurationInstance execute(String configuration, String requestType, Map<String, Object> requestBody, Map<String, Object> requestParams, String requestOrigin) {
-        ConfigurationInstance ci = new ConfigurationInstance(configurations.get(requestType.toUpperCase()).get(configuration), requestBody, requestParams, requestOrigin, this, properties, scriptingHelper, mappingHelper, httpHelper, tracer);
+    public ConfigurationInstance execute(String configuration, String requestType, Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders, String requestOrigin) {
+        ConfigurationInstance ci = new ConfigurationInstance(configurations.get(requestType.toUpperCase()).get(configuration), requestBody, requestQuery, requestHeaders, requestOrigin, this, properties, scriptingHelper, mappingHelper, httpHelper, tracer);
 
         if (ci.getSteps() != null) {
             LoggingUtils.logInfo(log, "Request received for configuration: %s".formatted(configuration), requestOrigin, INCOMING_REQUEST);
-            if (allowedToExecuteConfiguration(requestBody, requestParams)) {
+            if (allowedToExecuteConfiguration(requestBody, requestQuery, requestHeaders)) {
                 ci.execute(configuration);
             }
             LoggingUtils.logInfo(log, "Request processed for configuration: %s".formatted(configuration), requestOrigin, INCOMING_RESPONSE);
@@ -75,9 +75,9 @@ public class ConfigurationService {
         return ci;
     }
 
-    private boolean allowedToExecuteConfiguration(Map<String, Object> requestBody, Map<String, Object> requestParams) {
+    private boolean allowedToExecuteConfiguration(Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders) {
         if (externalForwardingHelper.shouldForwardRequest()) {
-            ResponseEntity<Object> response = externalForwardingHelper.forwardRequest(requestBody, requestParams);
+            ResponseEntity<Object> response = externalForwardingHelper.forwardRequest(requestBody, requestQuery, requestHeaders);
             return externalForwardingHelper.isAllowedForwardingResponse(response.getStatusCodeValue());
         }
         return true;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ application:
     displayResponseContent: false
   incomingRequests:
     allowedMethodTypes: [ POST, GET ]
+    headers:
+      header: value
   httpCodesAllowList: [ 200, 201, 202 ]
   defaultServiceInCaseOfException:
     service: default-service

--- a/src/test/java/ee/buerokratt/ruuter/domain/ConfigurationInstanceTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/ConfigurationInstanceTest.java
@@ -1,0 +1,64 @@
+package ee.buerokratt.ruuter.domain;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import ee.buerokratt.ruuter.StepTestBase;
+import ee.buerokratt.ruuter.configuration.ApplicationProperties;
+import ee.buerokratt.ruuter.helper.HttpHelper;
+import ee.buerokratt.ruuter.helper.MappingHelper;
+import ee.buerokratt.ruuter.helper.ScriptingHelper;
+import ee.buerokratt.ruuter.service.ConfigurationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.sleuth.Tracer;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WireMockTest
+@ExtendWith(MockitoExtension.class)
+class ConfigurationInstanceTest {
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Mock
+    private ApplicationProperties properties;
+
+    @Mock
+    private ScriptingHelper scriptingHelper;
+
+    @Mock
+    private MappingHelper mappingHelper;
+
+    @Mock
+    private HttpHelper httpHelper;
+
+    @Mock
+    private Tracer tracer;
+
+    @Test
+    void execute_shouldAddGlobalHeadersToRequestHeaders() {
+        ConfigurationInstance ci = new ConfigurationInstance(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), "",
+            configurationService, properties, scriptingHelper, mappingHelper, httpHelper, tracer);
+        ApplicationProperties.IncomingRequests incomingRequests = new ApplicationProperties.IncomingRequests() {{
+            setHeaders(new HashMap<>() {{
+                put("header", "headerValue");
+            }});
+        }};
+        Map<String, String> incomingRequestsHeaders = new HashMap<>() {{
+            put("header", "headerValue");
+        }};
+
+        when(properties.getIncomingRequests()).thenReturn(incomingRequests);
+        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(incomingRequests.getHeaders());
+        when(mappingHelper.convertMapObjectValuesToString(anyMap())).thenReturn(incomingRequestsHeaders);
+        ci.execute("random-name");
+
+        assertEquals(incomingRequests.getHeaders(), ci.getRequestHeaders());
+    }
+}

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/AssignStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/AssignStepTest.java
@@ -34,7 +34,7 @@ class AssignStepTest extends StepTestBase {
         }};
 
         when(ci.getContext()).thenReturn(testContext);
-        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
+        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
         assignStep.execute(ci);
 
         assertEquals(expectedResult, ci.getContext().get("key"));
@@ -50,7 +50,7 @@ class AssignStepTest extends StepTestBase {
             }});
         }};
 
-        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
+        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
         when(ci.getContext()).thenReturn(testContext);
         assignStep.execute(ci);
 

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/AssignStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/AssignStepTest.java
@@ -17,24 +17,30 @@ class AssignStepTest extends StepTestBase {
 
     @Mock
     private ScriptingHelper scriptingHelper;
+    private HashMap<String, Object> testContext;
+    private String expectedResult;
 
     @BeforeEach
     protected void mockScriptingHelper() {
+        when(ci.getContext()).thenReturn(testContext);
         when(ci.getScriptingHelper()).thenReturn(scriptingHelper);
+        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
+    }
+
+    @BeforeEach
+    protected void initializeObjects() {
+        testContext = new HashMap<>();
+        expectedResult = "VALUE";
     }
 
     @Test
     void execute_shouldAssignVariableToContext() {
-        HashMap<String, Object> testContext = new HashMap<>();
-        String expectedResult = "VALUE";
         AssignStep<String> assignStep = new AssignStep<>() {{
             setAssign(new HashMap<>() {{
                 put("key", expectedResult);
             }});
         }};
 
-        when(ci.getContext()).thenReturn(testContext);
-        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
         assignStep.execute(ci);
 
         assertEquals(expectedResult, ci.getContext().get("key"));
@@ -42,16 +48,12 @@ class AssignStepTest extends StepTestBase {
 
     @Test
     void execute_shouldCallScriptingHelperWhenScriptFound() {
-        HashMap<String, Object> testContext = new HashMap<>();
-        String expectedResult = "EVALUATED";
         AssignStep<String> assignStep = new AssignStep<>() {{
             setAssign(new HashMap<>() {{
                 put("key", "${value}");
             }});
         }};
 
-        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
-        when(ci.getContext()).thenReturn(testContext);
         assignStep.execute(ci);
 
         assertEquals(expectedResult, ci.getContext().get("key"));

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/ReturnStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/ReturnStepTest.java
@@ -31,8 +31,8 @@ class ReturnStepTest extends StepTestBase {
             setReturnValue(expectedResult);
         }};
 
-        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(new HashMap<>());
-        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
+        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(new HashMap<>());
+        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
         returnStep.execute(ci);
 
         verify(ci, times(1)).setReturnValue(expectedResult);
@@ -45,8 +45,8 @@ class ReturnStepTest extends StepTestBase {
             setReturnValue("${value}");
         }};
 
-        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(new HashMap<>());
-        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
+        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(new HashMap<>());
+        when(scriptingHelper.evaluateScripts(anyString(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(expectedResult);
         returnStep.execute(ci);
 
         verify(ci, times(1)).setReturnValue(expectedResult);
@@ -71,10 +71,10 @@ class ReturnStepTest extends StepTestBase {
         Map<String, String> expectedResult = new HashMap<>();
         expectedResult.put("Set-Cookie", "cookieName=headerName; Domain=localhost; Secure; stringBoolean=false; Max-Age=300; Expires=2022-08-08T10:08:39.159Z; ");
 
-        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(headers);
+        when(scriptingHelper.evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap(), anyMap())).thenReturn(headers);
         returnStep.execute(ci);
 
-        verify(scriptingHelper, times(1)).evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap());
+        verify(scriptingHelper, times(1)).evaluateScripts(anyMap(), anyMap(), anyMap(), anyMap(), anyMap());
         verify(ci, times(1)).setReturnHeaders(expectedResult);
     }
 }

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/SwitchStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/SwitchStepTest.java
@@ -51,9 +51,9 @@ class SwitchStepTest extends StepTestBase {
         }};
 
         when(ci.getContext()).thenReturn(testContext);
-        when(scriptingHelper.evaluateScripts(eq("${currentTime == \"Sunday\"}"), eq(testContext), anyMap(), anyMap())).thenReturn(true);
-        when(scriptingHelper.evaluateScripts(eq("${currentTime == \"Saturday\"}"), eq(testContext), anyMap(), anyMap())).thenReturn(false);
-        when(scriptingHelper.evaluateScripts(eq("${currentTime == \"Friday\"}"), eq(testContext), anyMap(), anyMap())).thenReturn(false);
+        when(scriptingHelper.evaluateScripts(eq("${currentTime == \"Sunday\"}"), eq(testContext), anyMap(), anyMap(), anyMap())).thenReturn(true);
+        when(scriptingHelper.evaluateScripts(eq("${currentTime == \"Saturday\"}"), eq(testContext), anyMap(), anyMap(), anyMap())).thenReturn(false);
+        when(scriptingHelper.evaluateScripts(eq("${currentTime == \"Friday\"}"), eq(testContext), anyMap(), anyMap(), anyMap())).thenReturn(false);
         switchStep.execute(ci);
 
         assertEquals("fourth_step", switchStep.getNextStepName());

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/TemplateStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/TemplateStepTest.java
@@ -2,6 +2,7 @@ package ee.buerokratt.ruuter.domain.steps;
 
 import ee.buerokratt.ruuter.StepTestBase;
 import ee.buerokratt.ruuter.domain.ConfigurationInstance;
+import ee.buerokratt.ruuter.helper.MappingHelper;
 import ee.buerokratt.ruuter.helper.ScriptingHelper;
 import ee.buerokratt.ruuter.service.ConfigurationService;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +23,10 @@ class TemplateStepTest extends StepTestBase {
     private ScriptingHelper scriptingHelper;
 
     @Mock
-    ConfigurationInstance templateInstance;
+    private ConfigurationInstance templateInstance;
+
+    @Mock
+    private MappingHelper mappingHelper;
 
     @BeforeEach
     protected void mockDependencies() {
@@ -45,8 +49,9 @@ class TemplateStepTest extends StepTestBase {
 
         when(ci.getContext()).thenReturn(testContext);
         when(ci.getRequestOrigin()).thenReturn(requestOrigin);
+        when(ci.getMappingHelper()).thenReturn(mappingHelper);
         when(templateInstance.getReturnValue()).thenReturn(expectedResult);
-        when(configurationService.execute(templateToCall, "POST", new HashMap<>(), new HashMap<>(), requestOrigin)).thenReturn(templateInstance);
+        when(configurationService.execute(templateToCall, "POST", null, null, new HashMap<>(), requestOrigin)).thenReturn(templateInstance);
         templateStep.execute(ci);
 
         assertEquals(expectedResult, ci.getContext().get(resultName));

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/TemplateStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/TemplateStepTest.java
@@ -51,7 +51,7 @@ class TemplateStepTest extends StepTestBase {
         when(ci.getRequestOrigin()).thenReturn(requestOrigin);
         when(ci.getMappingHelper()).thenReturn(mappingHelper);
         when(templateInstance.getReturnValue()).thenReturn(expectedResult);
-        when(configurationService.execute(templateToCall, "POST", null, null, new HashMap<>(), requestOrigin)).thenReturn(templateInstance);
+        when(configurationService.execute(templateToCall, "POST", new HashMap<>(), new HashMap<>(), new HashMap<>(), requestOrigin)).thenReturn(templateInstance);
         templateStep.execute(ci);
 
         assertEquals(expectedResult, ci.getContext().get(resultName));

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/http/DefaultHttpServiceTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/http/DefaultHttpServiceTest.java
@@ -1,0 +1,165 @@
+package ee.buerokratt.ruuter.domain.steps.http;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import ee.buerokratt.ruuter.StepTestBase;
+import ee.buerokratt.ruuter.configuration.ApplicationProperties;
+import ee.buerokratt.ruuter.helper.HttpHelper;
+import ee.buerokratt.ruuter.helper.MappingHelper;
+import ee.buerokratt.ruuter.helper.ScriptingHelper;
+import ee.buerokratt.ruuter.service.ConfigurationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@WireMockTest
+class DefaultHttpServiceTest extends StepTestBase {
+
+
+    @Mock
+    private ApplicationProperties properties;
+
+    @Mock
+    private HttpHelper httpHelper;
+
+    @Mock
+    private MappingHelper mappingHelper;
+
+    @Mock
+    private ScriptingHelper scriptingHelper;
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Mock
+    private ApplicationProperties.HttpPost httpPost;
+
+    private HttpQueryArgs getArgs;
+
+    private HttpStep getStep;
+
+    private HttpQueryArgs postArgs;
+
+    private HttpStep postStep;
+
+    @BeforeEach
+    protected void mockDependencies() {
+        when(ci.getHttpHelper()).thenReturn(httpHelper);
+        when(ci.getMappingHelper()).thenReturn(mappingHelper);
+        when(ci.getScriptingHelper()).thenReturn(scriptingHelper);
+        when(ci.getProperties()).thenReturn(properties);
+    }
+
+    @BeforeEach
+    protected void initializeObjects(WireMockRuntimeInfo wireMockRuntimeInfo) {
+        getArgs = new HttpQueryArgs() {{
+            setQuery(new HashMap<>() {{
+                put("some_val", "Hello World");
+                put("another_val", 123);
+            }});
+            setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
+        }};
+        getStep = new HttpGetStep() {{
+            setName("get_message");
+            setArgs(getArgs);
+            setResultName("the_response");
+        }};
+        postArgs = new HttpQueryArgs() {{
+            setBody(new HashMap<>() {{
+                put("some_val", "Hello World");
+                put("another_val", 123);
+            }});
+            setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
+        }};
+        postStep = new HttpPostStep() {{
+            setName("post_message");
+            setArgs(postArgs);
+            setResultName("the_response");
+        }};
+    }
+
+    @Test
+    void execute_getRequestShouldExecuteDefaultDslWhenResponseCodeIsNotInWhitelist() {
+        DefaultHttpService defaultHttpService = Mockito.spy(new DefaultHttpService() {{
+            setService("default-dsl");
+            setBody(new HashMap<>());
+            setQuery(new HashMap<>());
+        }});
+        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
+
+        when(ci.getContext()).thenReturn(new HashMap<>());
+        when(ci.getConfigurationService()).thenReturn(configurationService);
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateScripts(getArgs.getQuery(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(getArgs.getQuery());
+        when(properties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
+        when(properties.getDefaultServiceInCaseOfException()).thenReturn(defaultHttpService);
+        getStep.execute(ci);
+
+        verify(configurationService, times(1)).execute("default-dsl", "POST", new HashMap<>(), new HashMap<>(), new HashMap<>(), null);
+    }
+
+    @Test
+    void execute_postRequestShouldExecuteDefaultDslWhenResponseCodeIsNotInWhitelist() {
+        DefaultHttpService defaultHttpService = Mockito.spy(new DefaultHttpService() {{
+            setService("default-dsl");
+            setBody(new HashMap<>());
+            setQuery(new HashMap<>());
+        }});
+        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
+
+        when(ci.getConfigurationService()).thenReturn(configurationService);
+        when(ci.getContext()).thenReturn(new HashMap<>());
+        when(ci.getMappingHelper()).thenReturn(mappingHelper);
+        when(httpHelper.doPost(postArgs.getUrl(), postArgs.getBody(), new HashMap<>(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateScripts(postArgs.getBody(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(postArgs.getBody());
+        when(properties.getHttpPost()).thenReturn(httpPost);
+        when(properties.getDefaultServiceInCaseOfException()).thenReturn(defaultHttpService);
+        when(properties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
+        postStep.execute(ci);
+
+        verify(configurationService, times(1)).execute("default-dsl", "POST", new HashMap<>(), new HashMap<>(), new HashMap<>(), null);
+    }
+
+    @Test
+    void execute_shouldExecuteStepSpecificDefaultDslWhenResponseCodeIsNotInWhitelist() {
+        DefaultHttpService defaultHttpService2 = Mockito.spy(new DefaultHttpService() {{
+            setService("default-dsl2");
+            setBody(new HashMap<>());
+            setQuery(new HashMap<>());
+        }});
+        getStep.setLocalHttpExceptionService(defaultHttpService2);
+        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
+
+        when(ci.getContext()).thenReturn(new HashMap<>());
+        when(ci.getConfigurationService()).thenReturn(configurationService);
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateScripts(getArgs.getQuery(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(getArgs.getQuery());
+        when(properties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
+        getStep.execute(ci);
+
+        verify(configurationService, times(1)).execute("default-dsl2", "POST", new HashMap<>(), new HashMap<>(), new HashMap<>(), null);
+    }
+
+    @Test
+    void execute_shouldNotExecuteDefaultDslWhenRequestIsInvalidButDefaultDslIsNotDefined() {
+        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
+
+        when(ci.getContext()).thenReturn(new HashMap<>());
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateScripts(getArgs.getQuery(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(getArgs.getQuery());
+        when(properties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
+        getStep.execute(ci);
+
+        verify(configurationService, times(0)).execute(anyString(), anyString(), anyMap(), anyMap(), anyMap(), anyString());
+    }
+}

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStepTest.java
@@ -6,6 +6,7 @@ import ee.buerokratt.ruuter.StepTestBase;
 import ee.buerokratt.ruuter.configuration.ApplicationProperties;
 import ee.buerokratt.ruuter.helper.HttpHelper;
 import ee.buerokratt.ruuter.helper.MappingHelper;
+import ee.buerokratt.ruuter.helper.ScriptingHelper;
 import ee.buerokratt.ruuter.service.ConfigurationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -34,130 +36,108 @@ class HttpGetStepTest extends StepTestBase {
     private MappingHelper mappingHelper;
 
     @Mock
+    private ScriptingHelper scriptingHelper;
+
+    @Mock
     private ConfigurationService configurationService;
+
+    private HttpQueryArgs getArgs;
+
+    private HttpStep getStep;
+
+    private Map<String, Map<String, Object>> evaluatedParameters;
 
     @BeforeEach
     protected void mockDependencies() {
         when(ci.getHttpHelper()).thenReturn(httpHelper);
+        when(ci.getMappingHelper()).thenReturn(mappingHelper);
+        when(ci.getScriptingHelper()).thenReturn(scriptingHelper);
         when(ci.getProperties()).thenReturn(applicationProperties);
     }
 
-    @Test
-    void execute_shouldQueryEndpointAndStoreResponse(WireMockRuntimeInfo wireMockRuntimeInfo) {
-        HashMap<String, Object> testContext = new HashMap<>();
-        HttpQueryArgs expectedGetArgs = new HttpQueryArgs() {{
+    @BeforeEach
+    protected void initializeObjects(WireMockRuntimeInfo wireMockRuntimeInfo) {
+        getArgs = new HttpQueryArgs() {{
             setQuery(new HashMap<>() {{
                 put("some_val", "Hello World");
                 put("another_val", 123);
             }});
             setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
         }};
-        HttpStep expectedGetStep = new HttpGetStep() {{
+        getStep = new HttpGetStep() {{
             setName("get_message");
-            setArgs(expectedGetArgs);
+            setArgs(getArgs);
             setResultName("the_response");
         }};
+        evaluatedParameters = new HashMap<>() {{
+            put("query", getArgs.getQuery());
+        }};
+    }
+
+    @Test
+    void execute_shouldQueryEndpointAndStoreResponse() {
+        Map<String, Object> testContext = new HashMap<>();
         ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.OK);
 
-        when(ci.getMappingHelper()).thenReturn(mappingHelper);
         when(ci.getContext()).thenReturn(testContext);
-        when(httpHelper.doGet(expectedGetArgs.getUrl(), expectedGetArgs.getQuery(), expectedGetArgs.getHeaders())).thenReturn(httpResponse);
-        expectedGetStep.execute(ci);
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateRequestParameters(ci, null, getArgs.getQuery(), new HashMap<>())).thenReturn(evaluatedParameters);
+        getStep.execute(ci);
 
         assertEquals(HttpStatus.OK, ((HttpStepResult) testContext.get("the_response")).getResponse().getStatusCode());
         assertEquals(httpResponse.getBody(), ((HttpStepResult) testContext.get("the_response")).getResponse().getBody());
     }
 
     @Test
-    void execute_shouldExecuteDefaultActionWhenRequestIsInvalidAndStopInCaseOfExceptionIsTrue(WireMockRuntimeInfo wireMockRuntimeInfo) {
+    void execute_shouldExecuteDefaultActionWhenRequestIsInvalidAndStopInCaseOfExceptionIsTrue() {
         DefaultHttpService defaultHttpService = Mockito.spy(new DefaultHttpService() {{
             setService("default-action");
             setBody(new HashMap<>());
             setQuery(new HashMap<>());
         }});
-        HashMap<String, Object> testContext = new HashMap<>();
-        HttpQueryArgs expectedGetArgs = new HttpQueryArgs() {{
-            setQuery(new HashMap<>() {{
-                put("some_val", "Hello World");
-                put("another_val", 123);
-            }});
-            setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
-        }};
-        HttpStep failingGetStep = new HttpGetStep() {{
-            setName("get_message");
-            setArgs(expectedGetArgs);
-            setResultName("the_response");
-        }};
         ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
 
-        when(httpHelper.doGet(expectedGetArgs.getUrl(), expectedGetArgs.getQuery(), expectedGetArgs.getHeaders())).thenReturn(httpResponse);
+        when(ci.getContext()).thenReturn(new HashMap<>());
         when(ci.getConfigurationService()).thenReturn(configurationService);
-        when(ci.getContext()).thenReturn(testContext);
-        when(ci.getRequestOrigin()).thenReturn("");
-        when(ci.getMappingHelper()).thenReturn(mappingHelper);
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateRequestParameters(ci, null, getArgs.getQuery(), new HashMap<>())).thenReturn(evaluatedParameters);
         when(applicationProperties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
         when(applicationProperties.getDefaultServiceInCaseOfException()).thenReturn(defaultHttpService);
-        failingGetStep.execute(ci);
+        getStep.execute(ci);
 
-        verify(configurationService, times(1)).execute(eq("default-action"), anyString(), anyMap(), anyMap(), anyString());
+        verify(configurationService, times(1)).execute("default-action", "POST", null, null, new HashMap<>(), null);
     }
 
     @Test
-    void execute_shouldExecuteStepSpecificDefaultActionWhenRequestIsInvalidAndStopInCaseOfExceptionIsTrue(WireMockRuntimeInfo wireMockRuntimeInfo) {
+    void execute_shouldExecuteStepSpecificDefaultActionWhenRequestIsInvalidAndStopInCaseOfExceptionIsTrue() {
         DefaultHttpService defaultHttpService2 = Mockito.spy(new DefaultHttpService() {{
             setService("default-action2");
             setBody(new HashMap<>());
             setQuery(new HashMap<>());
         }});
-        HashMap<String, Object> testContext = new HashMap<>();
-        HttpQueryArgs expectedGetArgs = new HttpQueryArgs() {{
-            setQuery(new HashMap<>() {{
-                put("some_val", "Hello World");
-                put("another_val", 123);
-            }});
-            setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
-        }};
-        HttpStep failingGetStep = new HttpGetStep() {{
-            setName("get_message");
-            setArgs(expectedGetArgs);
-            setResultName("the_response");
-            setLocalHttpExceptionService(defaultHttpService2);
-        }};
+        getStep.setLocalHttpExceptionService(defaultHttpService2);
         ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
 
-        when(httpHelper.doGet(expectedGetArgs.getUrl(), expectedGetArgs.getQuery(), expectedGetArgs.getHeaders())).thenReturn(httpResponse);
+        when(ci.getContext()).thenReturn(new HashMap<>());
         when(ci.getConfigurationService()).thenReturn(configurationService);
-        when(ci.getMappingHelper()).thenReturn(mappingHelper);
-        when(ci.getContext()).thenReturn(testContext);
-        when(ci.getRequestOrigin()).thenReturn("");
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateRequestParameters(ci, null, getArgs.getQuery(), new HashMap<>())).thenReturn(evaluatedParameters);
         when(applicationProperties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
-        failingGetStep.execute(ci);
+        getStep.execute(ci);
 
-        verify(configurationService, times(1)).execute(eq("default-action2"), eq("POST"), anyMap(), anyMap(), anyString());
+        verify(configurationService, times(1)).execute("default-action2", "POST", null, null, new HashMap<>(), null);
     }
 
     @Test
-    void execute_shouldNotExecuteDefaultActionWhenRequestIsInvalidButDefaultActionIsNotDefined(WireMockRuntimeInfo wireMockRuntimeInfo) {
-        HashMap<String, Object> testContext = new HashMap<>();
-        HttpQueryArgs expectedGetArgs = new HttpQueryArgs() {{
-            setQuery(new HashMap<>() {{
-                put("some_val", "Hello World");
-                put("another_val", 123);
-            }});
-            setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
-        }};
-        HttpStep expectedGetStep = new HttpGetStep() {{
-            setName("get_message");
-            setArgs(expectedGetArgs);
-            setResultName("the_response");
-        }};
+    void execute_shouldNotExecuteDefaultActionWhenRequestIsInvalidButDefaultActionIsNotDefined() {
         ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
 
-        when(ci.getContext()).thenReturn(testContext);
-        when(ci.getHttpHelper().doGet(expectedGetArgs.getUrl(), expectedGetArgs.getQuery(), expectedGetArgs.getHeaders())).thenReturn(httpResponse);
+        when(ci.getContext()).thenReturn(new HashMap<>());
+        when(httpHelper.doGet(getArgs.getUrl(), getArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateRequestParameters(ci, null, getArgs.getQuery(), new HashMap<>())).thenReturn(evaluatedParameters);
         when(applicationProperties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
-        expectedGetStep.execute(ci);
+        getStep.execute(ci);
 
-        verify(configurationService, times(0)).execute(anyString(), anyString(), anyMap(), anyMap(), anyString());
+        verify(configurationService, times(0)).execute(anyString(), anyString(), anyMap(), anyMap(), anyMap(), anyString());
     }
 }

--- a/src/test/java/ee/buerokratt/ruuter/domain/steps/http/HttpPostStepTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/domain/steps/http/HttpPostStepTest.java
@@ -7,20 +7,19 @@ import ee.buerokratt.ruuter.configuration.ApplicationProperties;
 import ee.buerokratt.ruuter.helper.HttpHelper;
 import ee.buerokratt.ruuter.helper.MappingHelper;
 import ee.buerokratt.ruuter.helper.ScriptingHelper;
-import ee.buerokratt.ruuter.service.ConfigurationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.mockito.Mockito;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.when;
 
 @WireMockTest
 class HttpPostStepTest extends StepTestBase {
@@ -38,25 +37,23 @@ class HttpPostStepTest extends StepTestBase {
     private ScriptingHelper scriptingHelper;
 
     @Mock
-    private ConfigurationService configurationService;
-
-    @Mock
     private ApplicationProperties.HttpPost httpPost;
 
     @Mock
     private ApplicationProperties.Logging logging;
 
     private HttpQueryArgs postArgs;
-
     private HttpStep postStep;
-
-    private Map<String, Map<String, Object>> evaluatedParameters;
+    private Map<String, Object> testContext;
+    private ResponseEntity<Object> httpResponse;
 
     @BeforeEach
     protected void mockDependencies() {
         when(ci.getProperties()).thenReturn(properties);
         when(ci.getHttpHelper()).thenReturn(httpHelper);
+        when(ci.getMappingHelper()).thenReturn(mappingHelper);
         when(ci.getScriptingHelper()).thenReturn(scriptingHelper);
+        when(properties.getHttpPost()).thenReturn(httpPost);
     }
 
     @BeforeEach
@@ -67,28 +64,21 @@ class HttpPostStepTest extends StepTestBase {
                 put("another_val", 123);
             }});
             setUrl("http://localhost:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
-            setHeaders(new HashMap<>());
         }};
         postStep = new HttpPostStep() {{
             setName("post_message");
             setArgs(postArgs);
             setResultName("the_response");
         }};
-        evaluatedParameters = new HashMap<>() {{
-            put("body", postArgs.getBody());
-        }};
+        testContext = new HashMap<>();
+        httpResponse = new ResponseEntity<>("body", null, HttpStatus.OK);
     }
 
     @Test
     void execute_shouldSendPostRequestAndStoreResponse() {
-        Map<String, Object> testContext = new HashMap<>();
-        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.OK);
-
         when(ci.getContext()).thenReturn(testContext);
-        when(ci.getMappingHelper()).thenReturn(mappingHelper);
-        when(httpHelper.doPost(postArgs.getUrl(), postArgs.getBody(), postArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
-        when(scriptingHelper.evaluateRequestParameters(ci, postArgs.getBody(), null, new HashMap<>())).thenReturn(evaluatedParameters);
-        when(properties.getHttpPost()).thenReturn(httpPost);
+        when(httpHelper.doPost(postArgs.getUrl(), postArgs.getBody(), new HashMap<>(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateScripts(postArgs.getBody(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(postArgs.getBody());
         when(properties.getLogging()).thenReturn(logging);
         when(httpPost.getHeaders()).thenReturn(new HashMap<>());
         postStep.execute(ci);
@@ -97,50 +87,34 @@ class HttpPostStepTest extends StepTestBase {
     }
 
     @Test
-    void execute_shouldExecuteDefaultActionWhenResponseCodeIsNotInWhitelist() {
-        DefaultHttpService defaultHttpService = Mockito.spy(new DefaultHttpService() {{
-            setService("default-action");
-            setBody(new HashMap<>());
-            setQuery(new HashMap<>());
-        }});
-        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.CREATED);
-
-        when(ci.getConfigurationService()).thenReturn(configurationService);
-        when(ci.getContext()).thenReturn(new HashMap<>());
-        when(ci.getMappingHelper()).thenReturn(mappingHelper);
-        when(httpHelper.doPost(postArgs.getUrl(), postArgs.getBody(), postArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
-        when(scriptingHelper.evaluateRequestParameters(ci, postArgs.getBody(), null, new HashMap<>())).thenReturn(evaluatedParameters);
-        when(properties.getHttpPost()).thenReturn(httpPost);
-        when(properties.getDefaultServiceInCaseOfException()).thenReturn(defaultHttpService);
-        when(properties.getHttpCodesAllowList()).thenReturn(new ArrayList<>() {{add(HttpStatus.OK.value());}});
-        postStep.execute(ci);
-
-        verify(configurationService, times(1)).execute("default-action", "POST", null, null, new HashMap<>(), null);
-    }
-
-    @Test
     void execute_shouldAddDefaultHeadersDefinedInSettingsFileToRequest() {
         postArgs.setHeaders(new HashMap<>() {{
             put("header1", "value1");
         }});
-        Map<String, Object> headers = new HashMap<>() {{
-            put("header1", "value1");
-            put("header2", "value2");
-        }};
         ApplicationProperties.HttpPost httpPost = new ApplicationProperties.HttpPost() {{
             setHeaders(new HashMap<>() {{
                 put("header2", "value2");
             }});
         }};
-        ResponseEntity<Object> httpResponse = new ResponseEntity<>("body", null, HttpStatus.OK);
 
         when(ci.getContext()).thenReturn(new HashMap<>());
-        when(ci.getMappingHelper()).thenReturn(mappingHelper);
-        when(httpHelper.doPost(postArgs.getUrl(), postArgs.getBody(), postArgs.getQuery(), new HashMap<>())).thenReturn(httpResponse);
-        when(scriptingHelper.evaluateRequestParameters(ci, postArgs.getBody(), null, headers)).thenReturn(evaluatedParameters);
+        when(httpHelper.doPost(postArgs.getUrl(), postArgs.getBody(), new HashMap<>(), new HashMap<>())).thenReturn(httpResponse);
+        when(scriptingHelper.evaluateScripts(postArgs.getBody(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(postArgs.getBody());
         when(properties.getHttpPost()).thenReturn(httpPost);
         postStep.execute(ci);
 
         assertEquals("value2", postStep.getArgs().getHeaders().get("header2"));
+    }
+
+    @Test
+    void execute_shouldThrowErrorWhenUrlIsInvalid(WireMockRuntimeInfo wireMockRuntimeInfo) {
+        postStep.getArgs().setUrl("http://notFounUrl:%s/endpoint".formatted(wireMockRuntimeInfo.getHttpPort()));
+
+        when(ci.getContext()).thenReturn(testContext);
+        when(scriptingHelper.evaluateScripts(postArgs.getBody(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>())).thenReturn(postArgs.getBody());
+        when(properties.getStopInCaseOfException()).thenReturn(true);
+        doCallRealMethod().when(httpHelper).doPost(postArgs.getUrl(), postArgs.getBody(), postArgs.getQuery(), new HashMap<>());
+
+        assertThrows(IllegalArgumentException.class, () -> postStep.execute(ci));
     }
 }

--- a/src/test/resources/domain/POST/call-template.yml
+++ b/src/test/resources/domain/POST/call-template.yml
@@ -4,7 +4,7 @@ call_template:
   body:
     element1: ${incoming.body.element1}
     element2: "2.0"
-  params:
+  query:
     element2: ${incoming.params.element2}
   result: templateResult
 


### PR DESCRIPTION
Add value into settings for defining custom headers on global settings level based on actual headers and/or custom values