### PR TITLE
fix: Remove unnecessary recursion in evaluateScripts when toEval inst…

### DIFF
--- a/src/main/java/ee/buerokratt/ruuter/helper/ScriptingHelper.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/ScriptingHelper.java
@@ -34,9 +34,6 @@ public class ScriptingHelper {
         if (toEval == null || !containsScript(toEval.toString())) {
             return toEval;
         }
-        if (toEval instanceof Map) {
-            return evaluateScripts(toEval, context, requestBody, requestQuery, requestHeaders);
-        }
 
         Map<String, Object> evalContext = setupEvalContext(context, requestBody, requestQuery, requestHeaders);
         Bindings bindings = createBindingsWithContext(evalContext);


### PR DESCRIPTION
Bugfix based on report https://github.com/buerokratt/Ruuter/discussions/132

Remove unnecessary recursion in evaluateScripts when toEval instanceof Map. Fixes stackoverflow when evaluating scripts in an incorrectly written conf.