### PR TITLE
#158 Allowlist of Ruuter services exposed as public REST endpoints

### DIFF
--- a/DSL/GET/internal/mock-response.yml
+++ b/DSL/GET/internal/mock-response.yml
@@ -1,0 +1,10 @@
+step_1:
+  call: reflect.mock
+  args:
+    response:
+      project: "Bürokratt"
+      website: "www.kratid.ee"
+  result: reflected_request
+
+step_2:
+  return: ${reflected_request.response}

--- a/samples/CONFIGURATION.md
+++ b/samples/CONFIGURATION.md
@@ -155,3 +155,17 @@ defaultServiceInCaseOfException:
 
 There is an example for POST requests. To add default headers to other requests in application.yml, define it in application.yml, also in
 ApplicationProperties class the same way as HttpPost is defined and use addHeaders method from HttpQueryArgs to add these default headers to the request.
+
+
+### Internal requests
+
+Some DSL services can be exposed to to internal requests as REST endpoints.
+These can be accessed only from IPs that are specified in `allowedFiletypes` configuration block:
+* `allowedIPs` - list of whitelisted IPs 
+* `allowedURLs` - list of whitelisted referral URLs
+
+```
+  internalRequests:
+    allowedIPs: ["127.0.0.1", "192.168.0.1", "172.21.0.1"]
+    allowedURLs: ["http://localhost/internalTest"]
+```

--- a/samples/CONFIGURATION.md
+++ b/samples/CONFIGURATION.md
@@ -159,7 +159,7 @@ ApplicationProperties class the same way as HttpPost is defined and use addHeade
 
 ### Internal requests
 
-Some DSL services can be exposed to to internal requests as REST endpoints.
+Some DSL services can be exposed to internal requests as REST endpoints.
 These can be accessed only from IPs that are specified in `allowedFiletypes` configuration block:
 * `allowedIPs` - list of whitelisted IPs 
 * `allowedURLs` - list of whitelisted referral URLs

--- a/samples/CONFIGURATION.md
+++ b/samples/CONFIGURATION.md
@@ -160,7 +160,7 @@ ApplicationProperties class the same way as HttpPost is defined and use addHeade
 ### Internal requests
 
 Some DSL services can be exposed to internal requests as REST endpoints.
-These can be accessed only from IPs that are specified in `allowedFiletypes` configuration block:
+These can be accessed only from IPs that are specified in `allowedIPs` configuration block:
 * `allowedIPs` - list of whitelisted IPs 
 * `allowedURLs` - list of whitelisted referral URLs
 

--- a/samples/GUIDE.md
+++ b/samples/GUIDE.md
@@ -108,6 +108,13 @@ Content-Type: application/json
 }
 ```
 
+### Internal services
+
+Requests put into first level subdirectory named `internal` will be 
+used for internal requests only. Those DSLs can only be accessed from 
+IPs and referrer URLs specified in configuration.
+
+
 ## Writing DSL files
 
 ### General functionalities

--- a/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
+++ b/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
@@ -25,6 +25,7 @@ public class ApplicationProperties {
     private Integer maxStepRecursions;
     private CORS cors;
     private DSL dsl;
+    private InternalRequests internalRequests;
 
     @Setter
     @Getter
@@ -81,5 +82,12 @@ public class ApplicationProperties {
     public static class DSL {
         private List<String> allowedFiletypes;
         private boolean allowDslReloading;
+    }
+
+    @Getter
+    @Setter
+    public static class InternalRequests {
+        private List<String> allowedIPs;
+        private List<String> allowedURLs;
     }
 }

--- a/src/main/java/ee/buerokratt/ruuter/domain/DslInstance.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/DslInstance.java
@@ -128,4 +128,8 @@ public class DslInstance {
         Map<String, Object> evaluatedHeaders = scriptingHelper.evaluateScripts(properties.getIncomingRequests().getHeaders(), context, requestBody, requestQuery, requestHeaders);
         requestHeaders.putAll(mappingHelper.convertMapObjectValuesToString(evaluatedHeaders));
     }
+
+    public boolean isInternal() {
+        return name.startsWith("internal");
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,9 @@ application:
   DSL:
     allowedFiletypes: [".yml", ".yaml", ".tmp"]
     allowDslReloading: true
+  internalRequests:
+    allowedIPs: ["127.0.0.1", "192.168.0.1", "172.21.0.1"]
+    allowedURLs: ["http://localhost/internalTest"]
 
 spring:
   application:


### PR DESCRIPTION
Added functionality to limit access to specific internal DSL's to specific IPs and referrers.