### PR TITLE
#178 Pass information about the original Ruuter endpoint to an external endpoint

### DIFF
--- a/samples/CONFIGURATION.md
+++ b/samples/CONFIGURATION.md
@@ -38,6 +38,9 @@ If the following values are defined, then every incoming request is forwarded to
 * `paramsToPass.get` - whether to forward query params from incoming request
 * `paramsToPass.post` - whether to forward body from incoming request
 * `paramsToPass.headers` - whether to forward headers from incoming request
+* `paramsToPass.origin` - whether to forward original Ruuter endpoint
+  * original endpoint and host is stored in query parameters `originalEndpoint` 
+  and `originalHost` respectively
 * `proceedPredicate.httpStatusCode` - defines the accepted http status codes for proceeding with DSL processing. If the external forwarding request
   receives a response not included in the list, then the request is not processed.
     * values can be defined as single status codes: `200`, `201`, `202`...
@@ -52,6 +55,7 @@ application:
                 GET: true
                 POST: false
                 headers: true
+                origin: true
             proceedPredicate:
                 httpStatusCode: [ 200..202, 204 ]
 ```

--- a/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
+++ b/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
@@ -55,6 +55,7 @@ public class ApplicationProperties {
                 private Boolean get;
                 private Boolean post;
                 private Boolean headers;
+                private Boolean origin;
             }
 
             @Getter

--- a/src/main/java/ee/buerokratt/ruuter/helper/ExternalForwardingHelper.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/ExternalForwardingHelper.java
@@ -7,6 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -28,31 +32,34 @@ public class ExternalForwardingHelper {
             properties.getIncomingRequests().getExternalForwarding().getProceedPredicate().getHttpStatusCode() != null;
     }
 
-    public ResponseEntity<Object> forwardRequest(Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders) {
-        return forwardRequest(requestBody, requestQuery,requestHeaders, this.getClass().getName());
+    public ResponseEntity<Object> forwardRequest(String dsl, Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders) {
+        return forwardRequest(dsl, requestBody, requestQuery,requestHeaders, this.getClass().getName());
     }
 
-    public ResponseEntity<Object> forwardRequest(Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders, String contentType) {
-        StringBuilder forwardingUrl = new StringBuilder(properties.getIncomingRequests().getExternalForwarding().getEndpoint());
+    public ResponseEntity<Object> forwardRequest(String dsl, Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders, String contentType) {
         String methodType = properties.getIncomingRequests().getExternalForwarding().getMethod().toUpperCase(Locale.ROOT);
         Map<String, Object> query = shouldAddQuery(requestQuery) ? requestQuery : new HashMap<>();
         Map<String, Object> body = shouldAddBody(requestBody) ? requestBody : new HashMap<>();
         Map<String, String> headers = shouldAddHeaders(requestHeaders) ? requestHeaders : new HashMap<>();
-        if (!query.isEmpty()) {
-            forwardingUrl.append("?");
-            int i = 0;
-            for (String key : query.keySet()) {
-                forwardingUrl.append(key).append("=").append(query.get(key));
-                i++;
-                if (i != query.keySet().size()) forwardingUrl.append("&");
-            }
+
+        if (shouldAddOrigin()) {
+            requestQuery.put("originalEndpoint", dsl);
+            if (requestHeaders.containsKey("host"))
+                requestQuery.put("originalHost", requestHeaders.get("host"));
         }
 
+        MultiValueMap<String, String> multibody = new LinkedMultiValueMap<>();
+        requestQuery.forEach((s, o) -> multibody.add(s, (String) o));
+
+        String forwardingUrl = UriComponentsBuilder.fromUriString(properties.getIncomingRequests().getExternalForwarding().getEndpoint())
+            .queryParams(multibody)
+            .toUriString();
+
         if (methodType.equals(HttpMethod.POST.name())) {
-            return httpHelper.doPost(forwardingUrl.toString(), body, query, headers, contentType);
+            return httpHelper.doPost(forwardingUrl, body, query, headers, contentType);
         }
         if (methodType.equals(HttpMethod.GET.name())) {
-            return httpHelper.doGet(forwardingUrl.toString(), query, headers);
+            return httpHelper.doGet(forwardingUrl, query, headers);
         }
         throw new InvalidHttpMethodTypeException(methodType);
     }
@@ -76,4 +83,9 @@ public class ExternalForwardingHelper {
     private boolean shouldAddHeaders(Map<String, String> requestHeaders) {
         return requestHeaders != null && Boolean.TRUE.equals(properties.getIncomingRequests().getExternalForwarding().getParamsToPass().getHeaders());
     }
+
+    private boolean shouldAddOrigin() {
+        return Boolean.TRUE.equals(properties.getIncomingRequests().getExternalForwarding().getParamsToPass().getOrigin());
+    }
+
 }

--- a/src/main/java/ee/buerokratt/ruuter/service/DslService.java
+++ b/src/main/java/ee/buerokratt/ruuter/service/DslService.java
@@ -118,7 +118,7 @@ public class DslService {
                 }
             }
 
-            if (allowedToExecuteDsl(requestBody, requestQuery, requestHeaders, contentType)) {
+            if (allowedToExecuteDsl(dsl, requestBody, requestQuery, requestHeaders, contentType)) {
                 di.execute();
             }
             LoggingUtils.logInfo(log, "Request processed for DSL: %s".formatted(dsl), requestOrigin, INCOMING_RESPONSE);
@@ -129,9 +129,9 @@ public class DslService {
         return di;
     }
 
-    private boolean allowedToExecuteDsl(Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders, String contentType) {
+    private boolean allowedToExecuteDsl(String dsl, Map<String, Object> requestBody, Map<String, Object> requestQuery, Map<String, String> requestHeaders, String contentType) {
         if (externalForwardingHelper.shouldForwardRequest()) {
-            ResponseEntity<Object> response = externalForwardingHelper.forwardRequest(requestBody, requestQuery, requestHeaders, contentType);
+            ResponseEntity<Object> response = externalForwardingHelper.forwardRequest(dsl, requestBody, requestQuery, requestHeaders, contentType);
             return externalForwardingHelper.isAllowedForwardingResponse(response.getStatusCodeValue());
         }
         return true;

--- a/src/test/java/ee/buerokratt/ruuter/helper/ExternalForwardingHelperTest.java
+++ b/src/test/java/ee/buerokratt/ruuter/helper/ExternalForwardingHelperTest.java
@@ -81,7 +81,7 @@ class ExternalForwardingHelperTest {
         }};
 
         when(spyProperties.getIncomingRequests()).thenReturn(incomingRequests);
-        helper.forwardRequest(requestBody, requestQuery, requestHeaders);
+        helper.forwardRequest("originaldsl", requestBody, requestQuery, requestHeaders);
 
         verify(spyHttpHelper, times(1)).doPost(externalForwarding.getEndpoint(), requestBody, requestQuery, new HashMap<>());
     }
@@ -105,7 +105,7 @@ class ExternalForwardingHelperTest {
         }};
 
         when(spyProperties.getIncomingRequests()).thenReturn(incomingRequests);
-        helper.forwardRequest(new HashMap<>(), requestQuery, requestHeaders);
+        helper.forwardRequest("originaldsl",new HashMap<>(), requestQuery, requestHeaders);
 
         verify(spyHttpHelper, times(1)).doGet(externalForwarding.getEndpoint(), requestQuery, new HashMap<>());
     }
@@ -121,7 +121,7 @@ class ExternalForwardingHelperTest {
 
         when(spyProperties.getIncomingRequests()).thenReturn(incomingRequests);
 
-        assertThrows(IllegalArgumentException.class, () -> helper.forwardRequest(new HashMap<>(), new HashMap<>(), new HashMap<>()));
+        assertThrows(IllegalArgumentException.class, () -> helper.forwardRequest("originaldsl",new HashMap<>(), new HashMap<>(), new HashMap<>()));
     }
 
     @Test


### PR DESCRIPTION
With refactoring to standard UriBuilder instead of brute-force building