### PR TITLE
Hotfix: add Access-Control-Allow-Credentials to CORS configuration

### DIFF
--- a/src/main/java/ee/buerokratt/ruuter/configuration/CORSConfiguration.java
+++ b/src/main/java/ee/buerokratt/ruuter/configuration/CORSConfiguration.java
@@ -19,6 +19,7 @@ public class CORSConfiguration {
                 String[] allowedOrigins = properties.getCors().getAllowedOrigins().toArray(new String[0]);
                 String[] allowedMethods = properties.getIncomingRequests().getAllowedMethodTypes().toArray(new String[0]);
                 registry.addMapping("/**")
+                    .allowCredentials(true)
                     .allowedOrigins(allowedOrigins)
                     .allowedMethods(allowedMethods);
             }


### PR DESCRIPTION
Added Access-Control-Allow-Credentials to server to fix CORS errors in Chatbot