### PR TITLE
227 dsl fails when guard has no exit code

### DIFF
--- a/samples/steps/http-post.md
+++ b/samples/steps/http-post.md
@@ -85,6 +85,7 @@ post_step:
   args:
     url: http://localhost:8080/nonexistant
     contentType: plaintext
+    error: error_step
     plaintext: 
         "byrokratt"
   result: the_message

--- a/src/main/java/ee/buerokratt/ruuter/service/DslService.java
+++ b/src/main/java/ee/buerokratt/ruuter/service/DslService.java
@@ -112,6 +112,12 @@ public class DslService {
             if (guard != null && guard.getSteps() != null) {
                 LoggingUtils.logInfo(log, "Executing guard for DSL: %s".formatted(dsl), requestOrigin, INCOMING_REQUEST);
                 guard.execute();
+
+                // In case the guard does not specifically return a status code or throw an exception, it
+                // should be considered as HTTP OK.
+                if (guard.getReturnStatus() != null)
+                    guard.setReturnStatus(HttpStatus.OK.value());
+
                 if (guard.getReturnStatus() != HttpStatus.OK.value()) {
                     LoggingUtils.logError(log, "Guard failed for DSL: %s".formatted(dsl), requestOrigin, INCOMING_RESPONSE);
                     return guard;


### PR DESCRIPTION
Changed so that when a .guard does not return with status code, it will be considered HTTP OK.

Also fixed a longstanding documentation typo.