### PR TITLE
#285 Block all request with unsolicited duplicate keys

### DIFF
--- a/samples/CONFIGURATION.md
+++ b/samples/CONFIGURATION.md
@@ -233,3 +233,8 @@ Default value is 256 (kB).
 ```
     "httpResponseSizeLimit": response size limit in KB
 ```
+
+### Allow duplicate request keys
+
+Duplicate keys in request JSON is allowed by default. 
+This functionality can be changed with setting `allowDuplicateRequestKeys` to false.

--- a/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
+++ b/src/main/java/ee/buerokratt/ruuter/configuration/ApplicationProperties.java
@@ -30,6 +30,8 @@ public class ApplicationProperties {
 
     private Integer httpResponseSizeLimit;
 
+    private Boolean allowDuplicateRequestKeys;
+
     @Setter
     @Getter
     public static class FinalResponse {

--- a/src/main/java/ee/buerokratt/ruuter/configuration/JacksonConfiguration.java
+++ b/src/main/java/ee/buerokratt/ruuter/configuration/JacksonConfiguration.java
@@ -1,18 +1,28 @@
 package ee.buerokratt.ruuter.configuration;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class JacksonConfiguration {
+
+    @Value("${application.allowDuplicateRequestKeys:false}")
+    private boolean allowDuplicateRequestKeys;
+
     @Bean
     @Primary
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        if (allowDuplicateRequestKeys)
+            return new ObjectMapper();
+        else
+            return new ObjectMapper().configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
+
     }
 
     @Bean

--- a/src/main/java/ee/buerokratt/ruuter/helper/OpenApiBuilder.java
+++ b/src/main/java/ee/buerokratt/ruuter/helper/OpenApiBuilder.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
-import io.swagger.v3.oas.models.parameters.RequestBody
+import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import org.springframework.web.bind.annotation.RequestParam;


### PR DESCRIPTION
Added a configuration value `application.allowDuplicateRequestKeys` (default: false) to turn this off or on.