### PR TITLE
Allow Ruuter to ignore Content-type of HTTP requests

### DIFF
--- a/samples/steps/http-get.md
+++ b/samples/steps/http-get.md
@@ -16,6 +16,8 @@ get_step:
 * `call`, with value `http.get` - determines the step type
 * `args`
     * `url` - the desired resource to query
+      * `contentType` - if set to `json_override` 
+  overrides response content type with application/json.
 
 **Optional fields:**
 

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpGetStep.java
@@ -22,7 +22,7 @@ public class HttpGetStep extends HttpStep {
         Map<String, Object> evaluatedQuery = di.getScriptingHelper().evaluateScripts(args.getQuery(), di.getContext(), di.getRequestBody(), di.getRequestQuery(), di.getRequestHeaders());
         Map<String, Object> evaluatedHeaders = di.getScriptingHelper().evaluateScripts(args.getHeaders(), di.getContext(), di.getRequestBody(), di.getRequestQuery(), di.getRequestHeaders());
         Map<String, String> mappedHeaders = di.getMappingHelper().convertMapObjectValuesToString(evaluatedHeaders);
-        return di.getHttpHelper().doMethod(HttpMethod.GET, evaluatedURL, evaluatedQuery, null, mappedHeaders, null, null, getLimit(), di, args.isDynamicParameters());
+        return di.getHttpHelper().doMethod(HttpMethod.GET, evaluatedURL, evaluatedQuery, null, mappedHeaders, args.getContentType() , null, getLimit(), di, args.isDynamicParameters());
     }
 
     @Override


### PR DESCRIPTION
If HTTP GET request has contentType=json_override consider the Content-Type to be application/json.