### PR TITLE
Fix bug in HttpStep onError parameter handling

### DIFF
--- a/src/main/java/ee/buerokratt/ruuter/domain/DslInstance.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/DslInstance.java
@@ -54,6 +54,8 @@ public class DslInstance {
 
     private final OpenSearchSender openSearchSender;
 
+    private String gotoStep = null;
+
     public void execute() {
         addGlobalIncomingHeadersToRequestHeaders();
         List<String> stepNames = steps.keySet().stream().toList();
@@ -120,7 +122,11 @@ public class DslInstance {
     }
 
     private void executeNextStep(DslStep previousStep, List<String> stepNames) {
-        if (Boolean.TRUE.equals(previousStep.getSkip()) || previousStep.getNextStepName() == null) {
+        if (getGotoStep() != null) {
+            DslStep nextStep = steps.get(getGotoStep());
+            setGotoStep(null);
+            executeNextStepWithoutMaxRecursionsExceeded(nextStep, stepNames);
+        } else if (Boolean.TRUE.equals(previousStep.getSkip()) || previousStep.getNextStepName() == null) {
             int nextStepIndex = stepNames.indexOf(previousStep.getName()) + 1;
             if (nextStepIndex >= stepNames.size()) {
                 return;

--- a/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpStep.java
+++ b/src/main/java/ee/buerokratt/ruuter/domain/steps/http/HttpStep.java
@@ -65,9 +65,8 @@ public abstract class HttpStep extends DslStep {
 
         if (!isAllowedHttpStatusCode(di, response.getStatusCodeValue())) {
             if (getOnErrorStep() != null) {
-                setNextStepName(getOnErrorStep());
-            }
-            else {
+                di.setGotoStep(getOnErrorStep());
+            } else {
                 di.setErrorStatus(HttpStatus.valueOf(response.getStatusCodeValue()));
                 di.setErrorMessage("HTTP returned with non-OK");
                 throw new IllegalArgumentException();


### PR DESCRIPTION
There was an bug with onError that sometimes overwrote next step value in memory, thus always returning error status afterwards.